### PR TITLE
Fix StringField min_length/max_length validation

### DIFF
--- a/aserializer/fields/validators.py
+++ b/aserializer/fields/validators.py
@@ -59,13 +59,13 @@ class CompareValidator(object):
 
 class MaxValueValidator(CompareValidator):
     compare = lambda self, a, b: a > b
-    message = 'Value is less than or equal to %(compare_value)s.'
+    message = 'Value is greater than %(compare_value)s.'
     error_code = 'max_value'
 
 
 class MinValueValidator(CompareValidator):
     compare = lambda self, a, b: a < b
-    message = 'Value is greater than or equal to %(compare_value)s.'
+    message = 'Value is less than %(compare_value)s.'
     error_code = 'min_value'
 
 

--- a/aserializer/fields/validators.py
+++ b/aserializer/fields/validators.py
@@ -43,11 +43,6 @@ class CompareValidator(object):
         self.compare_value = compare_value
 
     def __call__(self, value):
-        if isinstance(value, py2to3.string) and not isinstance(self.compare_value, py2to3.string):
-            try:
-                value = type(self.compare_value)(value)
-            except ValueError:
-                return
         if self.compare(value, self.compare_value):
             self.raise_validation_error(value)
 
@@ -56,14 +51,28 @@ class CompareValidator(object):
         raise SerializerValidatorError(message=self.message, error_code=self.error_code, params=params)
 
 
+class ConvertAndCompareValidator(CompareValidator):
+    """
+    Some fields might require casting of string values to the type of the compare_value.
 
-class MaxValueValidator(CompareValidator):
+    """
+    def __call__(self, value):
+        if isinstance(value, py2to3.string) and not isinstance(self.compare_value, py2to3.string):
+            try:
+                value = type(self.compare_value)(value)
+            except ValueError:
+                return
+
+        super(ConvertAndCompareValidator, self).__call__(value)
+
+
+class MaxValueValidator(ConvertAndCompareValidator):
     compare = lambda self, a, b: a > b
     message = 'Value is greater than %(compare_value)s.'
     error_code = 'max_value'
 
 
-class MinValueValidator(CompareValidator):
+class MinValueValidator(ConvertAndCompareValidator):
     compare = lambda self, a, b: a < b
     message = 'Value is less than %(compare_value)s.'
     error_code = 'min_value'

--- a/tests/field_tests.py
+++ b/tests/field_tests.py
@@ -250,6 +250,21 @@ class StringFieldTests(unittest.TestCase):
         self.assertRaises(IgnoreField, field.to_native)
         self.assertIsNone(field.to_python())
 
+    def test_max_min_length(self):
+        field = StringField(required=True, max_length=7, min_length=4)
+        field.set_value('foobar')
+        field.validate()
+        self.assertEqual(field.to_python(), 'foobar')
+        self.assertEqual(field.to_native(), 'foobar')
+
+        field = StringField(required=True, max_length=7, min_length=4)
+        field.set_value('foo')
+        self.assertRaises(SerializerFieldValueError, field.validate)
+
+        field = StringField(required=True, max_length=7, min_length=4)
+        field.set_value('foobarfoobar')
+        self.assertRaises(SerializerFieldValueError, field.validate)
+
 
 class UUIDFieldTests(unittest.TestCase):
 

--- a/tests/field_tests.py
+++ b/tests/field_tests.py
@@ -91,6 +91,10 @@ class IntegerFieldTests(unittest.TestCase):
         int_field.set_value(100)
         self.assertRaises(SerializerFieldValueError, int_field.validate)
 
+        int_field = IntegerField(required=True, max_value=24, min_value=22)
+        int_field.set_value(10)
+        self.assertRaises(SerializerFieldValueError, int_field.validate)
+
     def test_default(self):
         int_field = IntegerField(required=True, max_value=24, min_value=22, default=23)
         self.assertEqual(int_field.to_python(), 23)


### PR DESCRIPTION
The length validation is broken.
See in-depth explanation in https://github.com/onyg/aserializer/commit/723d558bf2751013b87907d227989a2ab959f842.